### PR TITLE
support old style op codes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,16 @@
 'use strict'
 
-const { Op } = require('sequelize');
+let { Op } = require('sequelize');
+
+if (!Op) {
+  // Support older versions of sequelize
+  Op = {
+    and: '$and',
+    or: '$or',
+    lt: '$lt',
+    gt: '$gt'
+  };
+}
 
 function encodeCursor(cursor) {
   return cursor ? Buffer.from(JSON.stringify(cursor)).toString('base64') : null;


### PR DESCRIPTION
I'm using sequelize 3.x on an old project. We're running into issues using nested conditions and limits as reported on that repository. Upgrading is too large of an effort, but using this library as a better way to manage pagination has been great.

The only problem is that this library assumes the newer syntax for sequelize op codes. Can we fall back to the old style of we're on an old versions? This PR does that.

I tested this in my app. I also (locally) changed the version of sequelize this project uses to 3.29.0, installed, and ran the test suite. It still passes on that version.