### PR TITLE
Allow providing no limit to get all the entities

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -97,6 +97,16 @@ test('paginates correctly when sort direction is descending', async t => {
   t.is(pagination.cursors.hasPrevious, true);
 });
 
+test('paginates correctly when limit is not provided', async t => {
+  const data = await generateTestData();
+
+  let pagination = await Test.paginate();
+
+  t.deepEqual(pagination.results.map(r => r.id), [1, 2, 3, 4, 5]);
+  t.is(pagination.cursors.hasNext, false);
+  t.is(pagination.cursors.hasPrevious, false);
+});
+
 test('paginates correctly when paginationField is not the primaryKeyField', async t => {
   const data = await generateTestData();
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ function withPagination({
       paranoid = true,
       subQuery,
       ...queryArgs
-    }) => {
+    } = {}) => {
       const decodedBefore = !!before ? decodeCursor(before) : null;
       const decodedAfter = !!after ? decodeCursor(after) : null;
       const cursorOrderIsDesc = before ? !desc : desc;
@@ -111,7 +111,7 @@ function withPagination({
         .findAll({
           where: whereQuery,
           include,
-          limit: limit + 1,
+          ...(limit && { limit: limit + 1 }),
           order,
           ...(Array.isArray(attributes) && attributes.length
             ? { attributes }


### PR DESCRIPTION
Makes `limit` an optional parameter.