### PR TITLE
Return the passed model from withPagination (for convinience)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,7 @@ function withPagination({
     };
 
     model[methodName] = paginate;
+    return model;
   };
 }
 


### PR DESCRIPTION
Seems like a logical thing to me. This way instead of this...

```js
constructor(Models) {
  this.Counter = Models.Counter;
  withPagination()(this.Counter);
}
```

...a developer can write this:

```js
constructor(Models) {
  this.Counter = withPagination()(Models.Counter);
}
```

What do you think?