### PR TITLE
new options(nest and mapToModel) added

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,8 @@ function withPagination({
       paginationField = primaryKeyField,
       raw = false,
       paranoid = true,
+      nest  = false,
+      mapToModel  = false,
       subQuery,
       ...queryArgs
     } = {}) => {
@@ -118,6 +120,8 @@ function withPagination({
             : {}),
           raw,
           paranoid,
+          nest,
+          mapToModel,
           ...(typeof subQuery === 'boolean' && { subQuery }),
           ...queryArgs,
         })


### PR DESCRIPTION
Use Case: when we want to pass the parameter raw: true, we can not convert dottie attributes to nested structure,