### PR TITLE
Pass queryArgs to count queries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,10 +43,12 @@ const withPagination = (options = {}) => (Model) => {
 
     const totalCountQueryOptions = {
       where,
+      ...queryArgs,
     };
 
     const cursorCountQueryOptions = {
       where: paginationWhere,
+      ...queryArgs,
     };
 
     const [instances, totalCount, cursorCount] = await Promise.all([


### PR DESCRIPTION
Fix wrong total count when inner join is used. For example:
```
Test.paginate({ 
limit: 2, 
include: [{
                    model: SomeModel,
                    required: true
                }],
 })

```