### PR TITLE
Allow chaining with a scope

### DIFF
--- a/src/makePaginate.ts
+++ b/src/makePaginate.ts
@@ -24,9 +24,10 @@ const makePaginate = <ModelType extends Model>(
 
   const omitPrimaryKeyFromOrder = options?.omitPrimaryKeyFromOrder ?? false;
 
-  const paginate = async (
+  const paginate = async function paginate (
+    this: ModelStatic<ModelType>,
     queryOptions: PaginateOptions<ModelType>,
-  ): Promise<PaginationConnection<ModelType>> => {
+  ): Promise<PaginationConnection<ModelType>> {
     const {
       order: orderOption,
       where,
@@ -74,9 +75,9 @@ const makePaginate = <ModelType extends Model>(
     };
 
     const [instances, totalCount, cursorCount] = await Promise.all([
-      model.findAll(paginationQueryOptions),
-      model.count(totalCountQueryOptions),
-      model.count(cursorCountQueryOptions),
+      this.findAll(paginationQueryOptions),
+      this.count(totalCountQueryOptions),
+      this.count(cursorCountQueryOptions),
     ]);
 
     if (before) {

--- a/src/tests/makePaginate.test.ts
+++ b/src/tests/makePaginate.test.ts
@@ -163,6 +163,22 @@ describe('makePaginate', () => {
     expect(result.totalCount).toBe(3);
   });
 
+  it('paginates correctly with a scope', async () => {
+    await generateTestData();
+
+    const order: OrderConfig = [['counter', 'ASC']];
+
+    const result = await (
+      Counter.scope({ method: ['extra', 3] }) as typeof Counter
+    ).paginate({
+      order,
+      limit: 5,
+    });
+
+    expectIdsToEqual(result, [5, 4, 3]);
+    expect(result.totalCount).toBe(3);
+  });
+
   it('paginates correctly with different order formats', async () => {
     await generateTestData();
 
@@ -180,5 +196,31 @@ describe('makePaginate', () => {
     result = await Counter.paginate({ order: [['counter', 'desc']], limit: 5 });
 
     expectIdsToEqual(result, [2, 3, 1, 4, 5]);
+  });
+
+  it('paginates correctly with simple order', async () => {
+    await generateTestData();
+
+    const order: OrderConfig = [['counter', 'ASC']];
+
+    let result = await Counter.paginate({ order, limit: 3 });
+
+    expectIdsToEqual(result, [5, 4, 1]);
+
+    result = await Counter.paginate({
+      order,
+      limit: 3,
+      after: result.pageInfo.endCursor as string,
+    });
+
+    expectIdsToEqual(result, [2, 3]);
+
+    result = await Counter.paginate({
+      order,
+      limit: 3,
+      before: result.pageInfo.startCursor as string,
+    });
+
+    expectIdsToEqual(result, [5, 4, 1]);
   });
 });

--- a/src/tests/models.ts
+++ b/src/tests/models.ts
@@ -30,5 +30,14 @@ Counter.init(
     counter: { type: DataTypes.INTEGER },
     extra: { type: DataTypes.INTEGER },
   },
-  { tableName: 'counters', sequelize },
+  {
+    tableName: 'counters',
+    sequelize,
+
+    scopes: {
+      extra(extra: number) {
+        return { where: { extra } };
+      },
+    },
+  },
 );


### PR DESCRIPTION
I use scopes a lot, and it helps a lot to be able to run this after a scope.

There is a `as typeof Counter` in the test, I think Sequelize's `scope` static method has a somewhat wrong type, but I am not sure.